### PR TITLE
Disable mark DNS record as proxied by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,7 @@ fn main() {
             let record_type = record.get("type").unwrap().as_str().unwrap();
             let record_name = record.get("name").unwrap().as_str().unwrap();
             let record_content = record.get("content").unwrap().as_str().unwrap();
+            let record_proxied = record.get("proxied").unwrap().as_bool().unwrap();
 
             if !cloudflare_records.contains(&record_name) || record_type != "A" {
                 continue
@@ -131,10 +132,11 @@ fn main() {
                 zone_id,
                 record_id);
             let record_update_body = format!(
-                r#"{{"name": "{}", "content": "{}", "type": "{}", "proxied": true}}"#,
+                r#"{{"name": "{}", "content": "{}", "type": "{}", "proxied": {}}}"#,
                 record_name,
                 current_ip,
-                record_type);
+                record_type,
+                record_proxied);
             cloudflare_api(&client, &*record_url, Some(record_update_body.to_string())).unwrap();
         }
     }


### PR DESCRIPTION
I think it makes more sense to leave the proxied unchanged, using
current config in the record itself.