### PR TITLE
Update cloudflare api to fix removed field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,21 +267,18 @@ checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "cloudflare"
-version = "0.10.1"
-source = "git+https://github.com/jcgruenhage/cloudflare-rs.git?branch=make-owner-fields-optional#02397fc4211886548a31a0731b240f2e17309de4"
+version = "0.12.0"
+source = "git+https://github.com/Wyn-Price/cloudflare-rs.git?branch=wyn/zone-details#a6179f8b3b520b17788f39fcd5f103e81a87a890"
 dependencies = [
- "anyhow",
- "async-trait",
- "base64 0.13.1",
- "cfg-if",
  "chrono",
  "http",
  "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",
- "serde_qs",
+ "serde_urlencoded",
  "serde_with",
+ "thiserror",
  "url",
  "uuid",
 ]
@@ -1437,17 +1434,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cac3f1e2ca2fe333923a1ae72caca910b98ed0630bb35ef6f8c8517d6e81afa"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,7 +1873,6 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 dependencies = [
- "getrandom",
  "serde",
 ]
 

--- a/Cargo.nix
+++ b/Cargo.nix
@@ -406,7 +406,7 @@ rec {
         features = {
           "default" = [ "std" ];
         };
-        resolvedDefaultFeatures = [ "alloc" "default" "std" ];
+        resolvedDefaultFeatures = [ "alloc" ];
       };
       "base64 0.21.4" = rec {
         crateName = "base64";
@@ -660,7 +660,7 @@ rec {
           "winapi" = [ "windows-targets" ];
           "windows-targets" = [ "dep:windows-targets" ];
         };
-        resolvedDefaultFeatures = [ "alloc" "android-tzdata" "clock" "default" "iana-time-zone" "js-sys" "oldtime" "serde" "std" "wasm-bindgen" "wasmbind" "winapi" "windows-targets" ];
+        resolvedDefaultFeatures = [ "alloc" "android-tzdata" "clock" "iana-time-zone" "js-sys" "serde" "std" "wasm-bindgen" "wasmbind" "winapi" "windows-targets" ];
       };
       "clap" = rec {
         crateName = "clap";
@@ -808,38 +808,24 @@ rec {
       };
       "cloudflare" = rec {
         crateName = "cloudflare";
-        version = "0.10.1";
+        version = "0.12.0";
         edition = "2018";
         workspace_member = null;
         src = pkgs.fetchgit {
-          url = "https://github.com/jcgruenhage/cloudflare-rs.git";
-          rev = "02397fc4211886548a31a0731b240f2e17309de4";
-          sha256 = "0njiqhsyxgl8064maj8shagvkamf6rb89k5wgxqkh47q1l0vi580";
+          url = "https://github.com/Wyn-Price/cloudflare-rs.git";
+          rev = "a6179f8b3b520b17788f39fcd5f103e81a87a890";
+          sha256 = "1myga8ys6i35qnwg16kcc212b8r0acpi8wyhmcvzk0vvffcbkw7k";
         };
         authors = [
-          "Areg Harutyunyan <areg@cloudflare.com>"
+          "Noah Kennedy <nkennedy@cloudflare.com>"
+          "Jeff Hiner <jhiner@cloudflare.com>"
         ];
         dependencies = [
           {
-            name = "anyhow";
-            packageId = "anyhow";
-          }
-          {
-            name = "async-trait";
-            packageId = "async-trait";
-          }
-          {
-            name = "base64";
-            packageId = "base64 0.13.1";
-          }
-          {
-            name = "cfg-if";
-            packageId = "cfg-if";
-          }
-          {
             name = "chrono";
             packageId = "chrono";
-            features = [ "serde" ];
+            usesDefaultFeatures = false;
+            features = [ "clock" "serde" "std" "wasmbind" ];
           }
           {
             name = "http";
@@ -853,7 +839,7 @@ rec {
             name = "reqwest";
             packageId = "reqwest";
             usesDefaultFeatures = false;
-            features = [ "json" "blocking" ];
+            features = [ "json" ];
           }
           {
             name = "serde";
@@ -865,12 +851,17 @@ rec {
             packageId = "serde_json";
           }
           {
-            name = "serde_qs";
-            packageId = "serde_qs";
+            name = "serde_urlencoded";
+            packageId = "serde_urlencoded";
           }
           {
             name = "serde_with";
             packageId = "serde_with";
+            features = [ "base64" ];
+          }
+          {
+            name = "thiserror";
+            packageId = "thiserror";
           }
           {
             name = "url";
@@ -879,12 +870,14 @@ rec {
           {
             name = "uuid";
             packageId = "uuid";
-            features = [ "serde" "v4" ];
+            features = [ "serde" ];
           }
         ];
         features = {
+          "blocking" = [ "reqwest/blocking" ];
           "default" = [ "default-tls" ];
           "default-tls" = [ "reqwest/default-tls" ];
+          "mockito" = [ "dep:mockito" ];
           "rustls-tls" = [ "reqwest/rustls-tls" ];
         };
         resolvedDefaultFeatures = [ "default" "default-tls" ];
@@ -4062,7 +4055,7 @@ rec {
           "wasm-streams" = [ "dep:wasm-streams" ];
           "webpki-roots" = [ "dep:webpki-roots" ];
         };
-        resolvedDefaultFeatures = [ "__tls" "blocking" "default-tls" "hyper-tls" "json" "native-tls-crate" "serde_json" "tokio-native-tls" ];
+        resolvedDefaultFeatures = [ "__tls" "default-tls" "hyper-tls" "json" "native-tls-crate" "serde_json" "tokio-native-tls" ];
       };
       "rustc-demangle" = rec {
         crateName = "rustc-demangle";
@@ -4414,44 +4407,6 @@ rec {
         };
         resolvedDefaultFeatures = [ "alloc" "default" "std" ];
       };
-      "serde_qs" = rec {
-        crateName = "serde_qs";
-        version = "0.10.1";
-        edition = "2018";
-        sha256 = "1yhsx3b1g1ccdzpkbfrh0vnrh2wirb575bm14cwk7zm25hg3zb4c";
-        authors = [
-          "Sam Scott <sam@osohq.com>"
-        ];
-        dependencies = [
-          {
-            name = "percent-encoding";
-            packageId = "percent-encoding";
-          }
-          {
-            name = "serde";
-            packageId = "serde";
-          }
-          {
-            name = "thiserror";
-            packageId = "thiserror";
-          }
-        ];
-        features = {
-          "actix-web2" = [ "dep:actix-web2" ];
-          "actix-web3" = [ "dep:actix-web3" ];
-          "actix-web4" = [ "dep:actix-web4" ];
-          "actix2" = [ "actix-web2" "futures" ];
-          "actix3" = [ "actix-web3" "futures" ];
-          "actix4" = [ "actix-web4" "futures" ];
-          "axum" = [ "axum-framework" "futures" ];
-          "axum-framework" = [ "dep:axum-framework" ];
-          "futures" = [ "dep:futures" ];
-          "tracing" = [ "dep:tracing" ];
-          "warp" = [ "futures" "tracing" "warp-framework" ];
-          "warp-framework" = [ "dep:warp-framework" ];
-        };
-        resolvedDefaultFeatures = [ "default" ];
-      };
       "serde_urlencoded" = rec {
         crateName = "serde_urlencoded";
         version = "0.7.1";
@@ -4565,7 +4520,7 @@ rec {
           "std" = [ "alloc" "serde/std" "chrono_0_4?/clock" "chrono_0_4?/std" "indexmap_1?/std" "time_0_3?/serde-well-known" "time_0_3?/std" ];
           "time_0_3" = [ "dep:time_0_3" ];
         };
-        resolvedDefaultFeatures = [ "alloc" "default" "macros" "std" ];
+        resolvedDefaultFeatures = [ "alloc" "base64" "default" "macros" "std" ];
       };
       "serde_with_macros" = rec {
         crateName = "serde_with_macros";
@@ -5821,12 +5776,6 @@ rec {
         ];
         dependencies = [
           {
-            name = "getrandom";
-            packageId = "getrandom";
-            rename = "getrandom";
-            optional = true;
-          }
-          {
             name = "serde";
             packageId = "serde";
             optional = true;
@@ -5860,7 +5809,7 @@ rec {
           "wasm-bindgen" = [ "dep:wasm-bindgen" ];
           "zerocopy" = [ "dep:zerocopy" ];
         };
-        resolvedDefaultFeatures = [ "default" "getrandom" "rng" "serde" "std" "v4" ];
+        resolvedDefaultFeatures = [ "default" "serde" "std" ];
       };
       "vcpkg" = rec {
         crateName = "vcpkg";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ log = "0.4.8"
 pretty_env_logger = "0.5.0"
 public-ip = "^0.2"
 tokio = { version = "^1", features = ["rt-multi-thread", "macros"] }
-cloudflare = "^0.10"
+cloudflare = "^0.12"
 anyhow = "^1"
 clap-verbosity-flag = "^2.0"
 local-ip-address = "^0.5.0"
@@ -19,7 +19,7 @@ version = "^4.4"
 features = ["wrap_help", "derive", "env"]
 
 [patch.crates-io]
-cloudflare = { git = "https://github.com/jcgruenhage/cloudflare-rs.git", branch = "make-owner-fields-optional" }
+cloudflare = { git = "https://github.com/Wyn-Price/cloudflare-rs.git", branch = "wyn/zone-details" }
 public-ip = { git = "https://github.com/jcgruenhage/rust-public-ip.git", branch = "cloudflare-provider" }
 
 [profile.release]

--- a/crate-hashes.json
+++ b/crate-hashes.json
@@ -1,4 +1,4 @@
 {
-  "cloudflare 0.10.1 (git+https://github.com/jcgruenhage/cloudflare-rs.git?branch=make-owner-fields-optional#02397fc4211886548a31a0731b240f2e17309de4)": "0njiqhsyxgl8064maj8shagvkamf6rb89k5wgxqkh47q1l0vi580",
-  "public-ip 0.2.2 (git+https://github.com/jcgruenhage/rust-public-ip.git?branch=cloudflare-provider#f0f0e68aebf9d796deaa3af04c8c6d4df3c515fe)": "0djzfp08rja39hyh9z9q180s4nycbixh5f19nglp78q087vn2dqc"
+  "git+https://github.com/Wyn-Price/cloudflare-rs.git?branch=wyn%2Fzone-details#cloudflare@0.12.0": "1myga8ys6i35qnwg16kcc212b8r0acpi8wyhmcvzk0vvffcbkw7k",
+  "git+https://github.com/jcgruenhage/rust-public-ip.git?branch=cloudflare-provider#public-ip@0.2.2": "0djzfp08rja39hyh9z9q180s4nycbixh5f19nglp78q087vn2dqc"
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -81,9 +81,9 @@ pub fn get_client(cli: &Cli) -> Result<Client> {
 		Err(anyhow::anyhow!("No valid credentials passed"))
 	}?;
 
-	Client::new(
+	Ok(Client::new(
 		credentials,
 		HttpApiClientConfig::default(),
 		Environment::Production,
-	)
+	)?)
 }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -9,10 +9,7 @@ use cloudflare::{
 		},
 		zone::{ListZones, ListZonesParams},
 	},
-	framework::{
-		async_api::{ApiClient, Client},
-		SearchMatch,
-	},
+	framework::{async_api::Client, SearchMatch},
 };
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::Arc;

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -1,7 +1,7 @@
 use crate::dns::{Fqdn, Requests, ZoneId};
 use anyhow::Result;
 use cloudflare::endpoints::dns::{DnsContent, DnsRecord};
-use cloudflare::framework::async_api::{ApiClient, Client};
+use cloudflare::framework::async_api::Client;
 use local_ip_address as local;
 use public_ip::{http, Version};
 use std::net::IpAddr;


### PR DESCRIPTION
A patch for cloudflare/cloudflare-rs/pull/240
Fixes #57

I've included @jcgruenhage's make-owner-fields-optional changes in my cloudflare-rs PR.

Removes some unused imports that no longer exist (`ApiClient`), and the change in `api.rs` is to coerce the error type from `Client::new`, as I'm assuming they're now returning their own error type. I can make this nicer if you want.

I can confirm that this works with `A` records, I haven't tested with `AAAA` records but I can't see why it wouldn't also work.

<details>
<summary>Before:</summary>

```
$ cargo run -- --records x.wynprice.com --token XXX
    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
     Running `target/debug/cfdyndns --records x.wynprice.com --token XXX`
 INFO  cfdyndns::ip > ...
Error: error decoding response body: missing field `multiple_railguns_allowed` at line 1 column 586
```
</details>

<details>
<summary>After - when there is no change needed:</summary>

```
$ cargo run -- --records x.wynprice.com --token XXX
   Compiling cfdyndns v0.2.0 (/home/wp/programming/cfdyndns)
    Finished dev [unoptimized + debuginfo] target(s) in 4.37s
     Running `target/debug/cfdyndns --records x.wynprice.com --token XXX`
 INFO  cfdyndns::ip > ...
 INFO  cfdyndns::dns > skipping A record `x.wynprice.com`; already up to date
```
</details>

<details>
<summary>After - when the DNS record needs changing:</summary>

```
$ cargo run -- --records x.wynprice.com --token XXX
   Compiling cfdyndns v0.2.0 (/home/wp/programming/cfdyndns)
    Finished dev [unoptimized + debuginfo] target(s) in 0.14s
     Running `target/debug/cfdyndns --records x.wynprice.com --token XXX`
 INFO  cfdyndns::ip > ...
 INFO  cfdyndns::dns > request: x.wynprice.com (... → ...)
```
</details>
